### PR TITLE
getRewardAddress is not a function - fix solved

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,10 +127,12 @@ Will return the same address as the one in `cardano.getUsedAddresses()`.
 ##### cardano.getRewardAddress()
 
 ```
-cardano.getRewardAddress() : RewardAddress
+cardano.getRewardAddresses() : [RewardAddress]
 ```
 
-`RewardAddress` is a hex encoded bytes string.
+`RewardAddresses` is a hex encoded bytes string.
+
+**Note** This function will return an array of length `1` and will always return the same single address.
 
 ##### cardano.getNetworkId()
 


### PR DESCRIPTION
When using the getRewardAddress() method, the error "getRewardAddress is not a function" is returned, according to CIP-0030 the correct method name is getRewardAddresses, wich returns an array.

On nami scope, it returns an array of length 1